### PR TITLE
add armv7l arch for Linux to support Raspbian

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,13 +29,13 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        arch: [ x64, arm64 ]
-        exclude:
-          - os: windows-latest
+        arch: [ x64 ]
+        include:
+          - os: ubuntu-latest
             arch: arm64
-          # macos arm64 give build errors
-          - os: macos-latest
-            arch: arm64
+            # for raspbian
+          - os: ubuntu-latest
+            arch: armv7l
     needs: release
     steps:
     - name: Checkout Code
@@ -69,6 +69,5 @@ jobs:
       run: yarn run publish --arch ${{ matrix.arch }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TARGET_ARG: ${{ matrix.arch }}
         WINDOWS_CODESIGN_CERTIFICATE: "./self-signed-cert.pfx"
         WINDOWS_CODESIGN_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}

--- a/forge.config.js
+++ b/forge.config.js
@@ -35,7 +35,6 @@ module.exports = {
     {
       name: "@electron-forge/maker-rpm",
       config: {},
-      platforms: process.env['TARGET_ARCH'] == "arm64" ? [] : ["linux"],
     }
   ],
   publishers: [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "easybloqs",
   "author": "Leaphy Robotics",
   "description": "Build Leaphy Arduino programs",
-  "version": "1.0.4-pre.3",
+  "version": "1.0.4-pre.4",
   "license": "GPLv3",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
remove workaround to disable RPM builds on non x64 arch